### PR TITLE
ft(buyer-cart): should allow a buyer to update their cart [#187364875]

### DIFF
--- a/src/controllers/cart.controller.ts
+++ b/src/controllers/cart.controller.ts
@@ -2,49 +2,91 @@ import { Response } from 'express';
 import { CartService } from '../service/cart.service';
 import { ProductService } from '../service/product.service';
 
-const addItemToCart = async (req: CustomRequest, res: Response) => {
-  try {
-    const userId = req.user;
-    if (!userId) {
-      return res.status(401).json({ message: 'Unauthorized' });
-    }
+export const cartController = {
+  async addItemToCart(req: CustomRequest, res: Response) {
+    try {
+      const userId = req.user;
+      if (!userId) {
+        return res.status(401).json({ message: 'Unauthorized' });
+      }
 
-    const { productid, quantity } = req.body;
-    const { user_id } = userId;
+      const { productid, quantity } = req.body;
+      const { user_id } = userId;
 
-    const productDetails = await ProductService.getProductById(productid);
-    if (!productDetails) {
-      return res.status(404).json({ message: 'Product not found.' });
-    }
-    if (productDetails.quantity < quantity) {
-      return res
-        .status(400)
-        .json({ message: 'Insufficient quantity available.' });
-    }
+      const productDetails = await ProductService.getProductById(productid);
+      if (!productDetails) {
+        return res.status(404).json({ message: 'Product not found.' });
+      }
+      if (productDetails.quantity < quantity) {
+        return res
+          .status(400)
+          .json({ message: 'Insufficient quantity available.' });
+      }
 
-    let cart = await CartService.getCartByUserId(user_id);
-    if (!cart) {
-      const cartData = {
-        userId: user_id,
-        products: [
-          { productId: productid, quantity, price: productDetails.price },
-        ],
-        totalPrice: productDetails.price * quantity,
-        totalQuantity: quantity,
-      };
-      cart = await CartService.saveToCart(cartData);
-    } else {
-      cart = await CartService.addToCart(cart, {
-        productId: productid,
+      let cart = await CartService.getCartByUserId(user_id);
+      if (!cart) {
+        const cartData = {
+          userId: user_id,
+          products: [
+            { productId: productid, quantity, price: productDetails.price },
+          ],
+          totalPrice: productDetails.price * quantity,
+          totalQuantity: quantity,
+        };
+        cart = await CartService.saveToCart(cartData);
+      } else {
+        cart = await CartService.addToCart(cart, {
+          productId: productid,
+          quantity,
+          price: productDetails.price,
+        });
+      }
+
+      res
+        .status(200)
+        .json({ message: 'Item added to cart successfully', cart });
+    } catch (error) {
+      res.status(500).json({ message: 'Internal server error' });
+    }
+  },
+
+  async updateItemInCart(req: CustomRequest, res: Response) {
+    try {
+      const userId = req.user;
+      if (!userId) {
+        return res.status(401).json({ message: 'Unauthorized' });
+      }
+
+      const { cartId } = req.params;
+      const { productId, quantity } = req.body;
+      const { user_id } = userId;
+
+      const productDetails = await ProductService.getProductById(productId);
+      console.log(productDetails);
+      if (!productDetails) {
+        return res.status(404).json({ message: 'Product not found.' });
+      }
+
+      if (productDetails.quantity < quantity) {
+        return res
+          .status(400)
+          .json({ message: 'Insufficient quantity available.' });
+      }
+
+      const cart = await CartService.updateProductInCart(
+        cartId,
+        user_id,
+        productId,
         quantity,
-        price: productDetails.price,
-      });
+      );
+
+      res.status(200).json({ message: 'Cart updated successfully', cart });
+    } catch (error: unknown) {
+      console.log(error);
+      if (error instanceof Error) {
+        return res.status(500).json({ error: error.message });
+      }
+      return res.status(500).json({ message: 'Internal server error' });
     }
-
-    res.status(200).json({ message: 'Item added to cart successfully', cart });
-  } catch (error) {
-    res.status(500).json({ message: 'Internal server error' });
-  }
+  },
 };
-
-export default addItemToCart;

--- a/src/docs/annotations/cart.docs.ts
+++ b/src/docs/annotations/cart.docs.ts
@@ -15,7 +15,7 @@
  *                 type: UUID
  *                 description: The id of the product.
  *                 example: c0abe869-6203-413f-b996-73b2361579b7
- *               quantity: 
+ *               quantity:
  *                 type: number
  *                 description: quantity in number
  *                 example: 3
@@ -53,6 +53,72 @@
  *                   type: string
  *                   description: Not Authorized.
  *                   example: JWT Expired or Malformed
+ *     tags:
+ *       - cart
+ */
+
+/**
+ * @openapi
+ * /api/v1/cart/updatecart/{cartId}:
+ *   patch:
+ *     summary: Update product(s) in cart
+ *     description: Updating items in the cart.
+ *     parameters:
+ *       - in: path
+ *         name: cartId
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: The id of the cart.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               productId:
+ *                 type: string
+ *                 description: The id of the product.
+ *                 example: c0abe869-6203-413f-b996-73b2361579b7
+ *               quantity:
+ *                 type: number
+ *                 description: The new quantity of the product.
+ *                 example: 3
+ *     responses:
+ *       '200':
+ *         description: Item updated in cart successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   description: Item updated in cart successfully.
+ *                   example: Item updated in cart successfully
+ *       '401':
+ *         description: Unauthorized
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   description: Unauthorized.
+ *                   example: Unauthorized
+ *       '404':
+ *         description: Product not found in cart or Cart not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   description: Product not found in cart or Cart not found.
+ *                   example: Product not found in cart
  *     tags:
  *       - cart
  */

--- a/src/routes/cart.route.ts
+++ b/src/routes/cart.route.ts
@@ -1,12 +1,22 @@
-import express from "express"
-import { isAuthenticated } from "../middleware/authentication/auth.middleware";
-import addItemToCart from "../controllers/cart.controller";
-import { dataSchema, validateSchema } from "../validations/cart.validation";
-
+import express from 'express';
+import { isAuthenticated } from '../middleware/authentication/auth.middleware';
+import { cartController } from '../controllers/cart.controller';
+import { validateSchema } from '../utils/joi.validateSchema';
+import { cartSchema } from '../validations/cart.validation';
 
 const cartRoute = express.Router();
 
-cartRoute.post("/cart/addtocart",[isAuthenticated, validateSchema(dataSchema)], addItemToCart)
-
+cartRoute.post(
+  '/cart/addtocart',
+  isAuthenticated,
+  validateSchema(cartSchema.addItem),
+  cartController.addItemToCart,
+);
+cartRoute.patch(
+  '/cart/updatecart/:cartId',
+  isAuthenticated,
+  validateSchema(cartSchema.updateItem),
+  cartController.updateItemInCart,
+);
 
 export default cartRoute;

--- a/src/utils/joi.validateSchema.ts
+++ b/src/utils/joi.validateSchema.ts
@@ -1,0 +1,15 @@
+import Joi from 'joi';
+import { Request, Response, NextFunction } from 'express';
+
+export const validateSchema = (schema: Joi.ObjectSchema) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      req.body = await schema.validateAsync(req.body);
+      next();
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        return res.status(400).json({ message: error.message });
+      }
+    }
+  };
+};

--- a/src/validations/cart.validation.ts
+++ b/src/validations/cart.validation.ts
@@ -1,17 +1,20 @@
-import Joi from "joi";
-import { Request, Response, NextFunction } from 'express';
+import Joi from 'joi';
 
-export const validateSchema = (schema: Joi.ObjectSchema) => {
-  return (req: Request, res: Response, next: NextFunction) => {
-    const { error } = schema.validate(req.body);
-    if (error) {
-      return res.status(400).json({ message: error.message });
-    }
-    next();
-  };
+export const cartSchema = {
+  addItem: Joi.object({
+    productid: Joi.string().required(),
+    quantity: Joi.number().integer().positive().required(),
+  }),
+  updateItem: Joi.object({
+    productId: Joi.string().required().messages({
+      'string.empty': 'Product ID cannot be an empty string',
+      'string.base': 'Product ID must be a string',
+      'any.required': 'Product ID is required',
+    }),
+    quantity: Joi.number().integer().required().messages({
+      'number.base': 'Quantity must be a number',
+      'number.integer': 'Quantity must be an integer',
+      'any.required': 'Quantity is required',
+    }),
+  }),
 };
-
-export const dataSchema = Joi.object({
-  productid: Joi.string().required(),
-  quantity: Joi.number().integer().positive().required(),
-});

--- a/tests/cart.test.ts
+++ b/tests/cart.test.ts
@@ -1,46 +1,169 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import request from 'supertest';
-import {  server } from '../src/server';
-import { describe, expect, it, afterAll, beforeEach } from '@jest/globals';
+import { server } from '../src/server';
+import {
+  describe,
+  expect,
+  it,
+  afterAll,
+  beforeEach,
+  jest,
+} from '@jest/globals';
 import dotenv from 'dotenv';
+import AuthService from '../src/service/auth.service';
+import { CartService } from '../src/service/cart.service';
+import jwt from 'jsonwebtoken';
+jest.mock('../src/service/cart.service');
+jest.mock('../src/service/auth.service');
+
 dotenv.config();
 
-let token:any;
-let cartId:any;
+let cartId: any;
 const productId = '62414288-5be2-4e5c-b048-323bbeedd369';
 
 beforeEach(async () => {
-  const loginResponse = await request(server).post('/api/v1/auth/login').send({
-    email: 'tuyishimehope01@gmail.com',
-    password: '123456',
-  });
-  token = loginResponse.body.token;
+  server;
 });
 
 describe('POST /api/v1/cart', () => {
-    it('should add a product to the cart', async () => {
-        const response = await request(server)
-            .post('/api/v1/cart/addtocart')
-            .set('Cookie', `Authorization=${token}`)
-            .send({ productid: productId, quantity: 1 });
-    
-        expect(response.statusCode).toBe(200);
-        expect(response.body.message).toBe('Item added to cart successfully');
-        expect(response.body.cart).toBeInstanceOf(Object);
-        cartId = response.body.cart.id;
-    });
+  it('should add a product to the cart', async () => {
+    const email = 'tuyishimehope01@gmail.com';
+    const user = await AuthService.getUserByEmail(email);
 
-    it('should return 404 if product does not exist', async () => {
-        const nonExistentProductId = 'non-existent-product-id';
-        const response = await request(server)
-            .post('/api/v1/cart')
-            .set('Cookie', `Authorization=${token}`)
-            .send({ productid: nonExistentProductId, quantity: 1 });
+    if (user) {
+      const passwordRemoved = { ...user.toJSON(), password: undefined };
+      const token = jwt.sign(
+        { user: passwordRemoved },
+        process.env.JWT_SECRET || '',
+        { expiresIn: '1h' },
+      );
 
-        expect(response.statusCode).toBe(404);
-    })
-})
+      const response = await request(server)
+        .post('/api/v1/cart/addtocart')
+        .set('Cookie', `Authorization=${token}`)
+        .send({ productid: productId, quantity: 1 });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body.message).toBe('Item added to cart successfully');
+      expect(response.body.cart).toBeInstanceOf(Object);
+      cartId = response.body.cart.id;
+    }
+  });
+
+  it('should return 404 if product does not exist', async () => {
+    const nonExistentProductId = 'non-existent-product-id';
+    const email = 'tuyishimehope01@gmail.com';
+    const user = await AuthService.getUserByEmail(email);
+
+    if (user) {
+      const passwordRemoved = { ...user.toJSON(), password: undefined };
+      const token = jwt.sign(
+        { user: passwordRemoved },
+        process.env.JWT_SECRET || '',
+        { expiresIn: '1h' },
+      );
+
+      const response = await request(server)
+        .post('/api/v1/cart')
+        .set('Cookie', `Authorization=${token}`)
+        .send({ productid: nonExistentProductId, quantity: 1 });
+
+      expect(response.statusCode).toBe(404);
+    }
+  });
+});
+
+describe('PUT /api/v1/cart/updatecart/:cartId', () => {
+  it('should update the product quantity in the cart', async () => {
+    const email = 'tuyishimehope01@gmail.com';
+    const user = await AuthService.getUserByEmail(email);
+
+    if (user) {
+      const passwordRemoved = { ...user.toJSON(), password: undefined };
+      const token = jwt.sign(
+        { user: passwordRemoved },
+        process.env.JWT_SECRET || '',
+        { expiresIn: '1h' },
+      );
+
+      await request(server)
+        .post('/api/v1/cart/addtocart')
+        .set('Cookie', `Authorization=${token}`)
+        .send({ productid: productId, quantity: 1 });
+
+      const response = await request(server)
+        .put(`/api/v1/cart/updatecart/${cartId}`)
+        .set('Cookie', `Authorization=${token}`)
+        .send({ productId, quantity: 3 });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body.message).toBe('Cart updated successfully');
+      expect(response.body.cart).toBeInstanceOf(Object);
+      expect(response.body.cart.totalQuantity).toBeGreaterThan(0);
+      expect(response.body.cart.totalPrice).toBeGreaterThan(0);
+    }
+  });
+
+  it('should return 404 if product does not exist in the cart', async () => {
+    const email = 'tuyishimehope01@gmail.com';
+    const user = await AuthService.getUserByEmail(email);
+
+    if (user) {
+      const passwordRemoved = { ...user.toJSON(), password: undefined };
+      const token = jwt.sign(
+        { user: passwordRemoved },
+        process.env.JWT_SECRET || '',
+        { expiresIn: '1h' },
+      );
+
+      const response = await request(server)
+        .put(`/api/v1/cart/updatecart/${cartId}`)
+        .set('Cookie', `Authorization=${token}`)
+        .send({ productId: 'non-existent-product-id', quantity: 3 });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.body.message).toBe(
+        'Product does not exist in your cart. Consider adding it instead.',
+      );
+    }
+  });
+
+  it('should return 401 if user is not authenticated', async () => {
+    const response = await request(server)
+      .put(`/api/v1/cart/updatecart/${cartId}`)
+      .send({ productId, quantity: 3 });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('should return 500 for an internal server error', async () => {
+    const email = 'tuyishimehope01@gmail.com';
+    const user = await AuthService.getUserByEmail(email);
+
+    if (user) {
+      const passwordRemoved = { ...user.toJSON(), password: undefined };
+      const token = jwt.sign(
+        { user: passwordRemoved },
+        process.env.JWT_SECRET || '',
+        { expiresIn: '1h' },
+      );
+
+      jest
+        .spyOn(CartService, 'updateProductInCart')
+        .mockRejectedValue(new Error('Internal server error'));
+
+      const response = await request(server)
+        .put(`/api/v1/cart/updatecart/${cartId}`)
+        .set('Cookie', `Authorization=${token}`)
+        .send({ productId, quantity: 3 });
+
+      expect(response.statusCode).toBe(500);
+      expect(response.body.message).toBe('Internal server error');
+    }
+  });
+});
+
 afterAll(async () => {
   server.close();
 });


### PR DESCRIPTION
## ℹ️ Description

- Should allow a buyer to update their cart given a post request to their cart using cart_id
- The updated cart should be stored in the buyer's session
- The product details (name, price, image) should be retrieved from the database for each item in the updated cart
- The new cart total should be calculated by summing the prices of the items in the updated cart
- An updated cart confirmation message should be sent to the frontend to be displayed to the buyer


Fixes #(issue)

## 🧪 How can this be tested?

This should be tested on the swagger UI using cart endpoints

## 📍 Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature or Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## ✅ Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have created a loom video for the new feature or enhancement
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
