### PR TITLE
ft(Notifications): allow a user to mark all or one notification as read [#187364882]

### DIFF
--- a/src/controllers/notification.controller.ts
+++ b/src/controllers/notification.controller.ts
@@ -4,25 +4,75 @@ import { RequestUser } from '../middleware/user.authenticate';
 
 const getNotifications = async (req: RequestUser, res: Response) => {
   try {
-    if(!req.user){
+    if (!req.user) {
       return;
     }
     const userId = req.user.user_id;
-    
+
     if (!userId) {
-      return res.status(400).json({ message: "User ID is required" });
+      return res.status(400).json({ message: 'User ID is required' });
     }
 
-    const notifications = await NotificationService.getNotificationsByUserId(userId);
+    const notifications =
+      await NotificationService.getNotificationsByUserId(userId);
     return res
       .status(200)
-      .json({ message: "all notifications", notifications: notifications });
+      .json({ message: 'all notifications', notifications: notifications });
   } catch (error) {
     console.error(error);
-    return res
-      .status(500)
-      .json({ message: "Internal server error" });
+    return res.status(500).json({ message: 'Internal server error' });
   }
 };
 
-export { getNotifications };
+const markNotificationAsRead = async (req: RequestUser, res: Response) => {
+  try {
+    const { notificationId } = req.params;
+    if (!notificationId) {
+      return res.status(400).json({ message: 'Notification ID is required' });
+    }
+
+    if (!req.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    const userId = req.user.user_id;
+
+    const notification = await NotificationService.getNotificationByIdAndUserId(
+      notificationId,
+      userId,
+    );
+    if (!notification) {
+      return res.status(404).json({ message: 'Notification not found' });
+    }
+
+    if (notification.isRead) {
+      return res.status(200).json({ message: 'Notification is already read' });
+    }
+
+    await NotificationService.markNotificationAsRead(notificationId, userId);
+    return res.status(200).json({ message: 'Notification marked as read' });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ message: 'Internal server error' });
+  }
+};
+const markAllNotificationsAsRead = async (req: RequestUser, res: Response) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    const userId = req.user.user_id;
+
+    if (!userId) {
+      return res.status(400).json({ message: 'User ID is required' });
+    }
+
+    const message =
+      await NotificationService.markAllNotificationsAsRead(userId);
+    return res.status(200).json({ message });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ message: 'Internal server error' });
+  }
+};
+
+export { getNotifications, markNotificationAsRead, markAllNotificationsAsRead };

--- a/src/docs/annotations/notification.doc.ts
+++ b/src/docs/annotations/notification.doc.ts
@@ -47,6 +47,120 @@
 
 /**
  * @openapi
+ * /api/v1/notifications/{notificationId}/read:
+ *   patch:
+ *     summary: Mark a notification as read
+ *     description: Mark a specific notification as read for the logged-in user.
+ *     tags:
+ *       - Notifications
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: notificationId
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         required: true
+ *         description: ID of the notification to mark as read
+ *     responses:
+ *       200:
+ *         description: Notification marked as read successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Notification marked as read
+ *       400:
+ *         description: Bad request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Notification ID is required
+ *       401:
+ *         description: Unauthorized
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Unauthorized
+ *       403:
+ *         description: Forbidden
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Forbidden
+ *       500:
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Internal server error
+ */
+
+/**
+ * @openapi
+ * /api/v1/notifications/all/read:
+ *   patch:
+ *     summary: Mark all notifications as read
+ *     description: Mark all notifications as read for the logged-in user.
+ *     tags:
+ *       - Notifications
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: All notifications marked as read successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: All notifications marked as read
+ *       401:
+ *         description: Unauthorized
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Unauthorized
+ *       500:
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Internal server error
+ */
+
+/**
+ * @openapi
  * components:
  *   securitySchemes:
  *     bearerAuth:

--- a/src/models/notifications.model.ts
+++ b/src/models/notifications.model.ts
@@ -1,15 +1,13 @@
 /* eslint-disable require-jsdoc */
 import { UUID } from 'crypto';
-import { Model, DataTypes} from 'sequelize';
+import { Model, DataTypes } from 'sequelize';
 import { development, production, testing } from '../db/config';
 
 const isProduction = process.env.NODE_ENV === 'production';
 const isTesting = process.env.NODE_ENV === 'testing';
 const sequelize = isProduction ? production : isTesting ? testing : development;
 
-
-export class Notification extends Model
-{
+export class Notification extends Model {
   public id!: UUID;
 
   public message!: string;
@@ -19,29 +17,29 @@ export class Notification extends Model
   declare isRead: boolean;
 }
 
-  Notification.init(
-    {
-      id: {
-        type: DataTypes.UUID,
-        defaultValue: DataTypes.UUIDV4,
-        primaryKey: true,
-      },
-      message: DataTypes.STRING,
-      isRead: DataTypes.BOOLEAN,
-      userId: {
-        type: DataTypes.UUID,
-        allowNull: false,
-        references: {
-          model: 'users',
-          key: 'user_id',
-        },
+Notification.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    message: DataTypes.STRING,
+    isRead: DataTypes.BOOLEAN,
+    userId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: {
+        model: 'users',
+        key: 'user_id',
       },
     },
-    {
-      sequelize,
-      modelName: 'notification',
-      freezeTableName: true,
-    }
-  );
+  },
+  {
+    sequelize,
+    modelName: 'notification',
+    freezeTableName: true,
+  },
+);
 
-  export default Notification;
+export default Notification;

--- a/src/routes/notification.route.ts
+++ b/src/routes/notification.route.ts
@@ -1,10 +1,24 @@
-import express from "express";
-import { getNotifications } from "../controllers/notification.controller";
-import { isAuthenticated } from "../middleware/authentication/auth.middleware";
+import express from 'express';
+import {
+  getNotifications,
+  markNotificationAsRead,
+  markAllNotificationsAsRead,
+} from '../controllers/notification.controller';
+import { isAuthenticated } from '../middleware/authentication/auth.middleware';
 
 const notificationRoute = express.Router();
 
-notificationRoute.get('/notifications/all', isAuthenticated,getNotifications);
+notificationRoute.patch(
+  '/notifications/all/read',
+  isAuthenticated,
+  markAllNotificationsAsRead,
+);
+notificationRoute.patch(
+  '/notifications/:notificationId/read',
+  isAuthenticated,
+  markNotificationAsRead,
+);
 
+notificationRoute.get('/notifications/all', isAuthenticated, getNotifications);
 
 export default notificationRoute;

--- a/src/service/notification.service.ts
+++ b/src/service/notification.service.ts
@@ -6,6 +6,43 @@ class NotificationService {
       where: { userId: userId },
     });
   }
+
+  async getNotificationByIdAndUserId(notificationId: string, userId: string) {
+    return await Notification.findOne({
+      where: { id: notificationId, userId: userId },
+    });
+  }
+
+  async markNotificationAsRead(notificationId: string, userId: string) {
+    const notification = await Notification.findOne({
+      where: { id: notificationId, userId: userId },
+    });
+
+    if (!notification) {
+      throw new Error('Notification not found or unauthorized');
+    }
+
+    notification.isRead = true;
+    await notification.save();
+    return notification;
+  }
+
+  async markAllNotificationsAsRead(userId: string) {
+    const unreadNotifications = await Notification.findAll({
+      where: { userId, isRead: false },
+    });
+
+    if (unreadNotifications.length === 0) {
+      return 'All notifications are already read';
+    }
+
+    await Notification.update(
+      { isRead: true },
+      { where: { userId, isRead: false } },
+    );
+
+    return 'Notifications marked as read';
+  }
 }
 
 export default new NotificationService();

--- a/tests/readNotifications.test.ts
+++ b/tests/readNotifications.test.ts
@@ -1,0 +1,74 @@
+import request from 'supertest';
+import { configureApp, server } from '../src/server';
+import { sequelize } from '../src/db/config';
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import dotenv from 'dotenv';
+dotenv.config();
+const app = configureApp();
+
+let token: string | undefined;
+
+beforeEach(async () => {
+  const loginResponse = await request(app).post('/api/v1/auth/login').send({
+    email: 'twizald.02@gmail.com',
+    password: process.env.USER_PASSWORD_TESTS,
+  });
+  console.log(token);
+  token = loginResponse.body.token;
+});
+
+describe('NotificationController', () => {
+  beforeAll(async () => {
+    await sequelize.sync();
+  });
+
+  afterAll(async () => {
+    await sequelize.close();
+    server.close();
+  });
+
+  it('should get all notifications for a user', async () => {
+    const response = await request(app)
+      .get('/api/v1/notifications/all')
+      .set('Cookie', `Authorization=${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: 'all notifications',
+      notifications: expect.arrayContaining([
+        expect.objectContaining({ userId: expect.any(String) }),
+      ]),
+    });
+  });
+
+  it('should mark an unread notification as read', async () => {
+    const notificationId = '16c97af5-0fb8-46b5-a126-99e93359faf2';
+    const response = await request(app)
+      .patch(`/api/v1/notifications/${notificationId}/read`)
+      .set('Cookie', `Authorization=${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ message: 'Notification marked as read' });
+  });
+
+  it('should not mark an already read notification as read', async () => {
+    const notificationId = '16c97af5-0fb8-46b5-a126-99e93359faf2';
+    const response = await request(app)
+      .patch(`/api/v1/notifications/${notificationId}/read`)
+      .set('Cookie', `Authorization=${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ message: 'Notification is already read' });
+  });
+
+  it('should mark all notifications as read', async () => {
+    const response = await request(app)
+      .patch('/api/v1/notifications/all/read')
+      .set('Cookie', `Authorization=${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: 'All notifications are already read',
+    });
+  });
+});

--- a/tests/vendorController.test.ts
+++ b/tests/vendorController.test.ts
@@ -1,0 +1,201 @@
+import { Request, Response } from 'express';
+import { VendorService } from '../src/service/vendor.service';
+import { vendorController } from '../src/controllers/vendor.controller';
+import Vendor from '../src/models/vendor.model';
+import { jest, describe, beforeEach, it, expect } from '@jest/globals';
+import { CustomRequest } from '../src/middleware/authentication/auth.middleware';
+
+jest.mock('../src/models/vendor.model');
+
+describe('Vendor Controller', () => {
+  let req: Partial<CustomRequest>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    req = {};
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as Partial<Response>;
+  });
+
+  describe('getAllVendors', () => {
+    it('should retrieve all vendors successfully', async () => {
+      const vendors: Partial<Vendor>[] = [
+        {
+          store_name: 'Test Store 1',
+          store_description: 'This is a test store 1',
+          user_id: 'testuser1',
+        },
+        {
+          store_name: 'Test Store 2',
+          store_description: 'This is a test store 2',
+          user_id: 'testuser2',
+        },
+      ];
+
+      const getAllVendorsMock = jest.spyOn(VendorService, 'getAllVendors');
+      getAllVendorsMock.mockResolvedValueOnce(vendors as Vendor[]);
+
+      await vendorController.getAllVendors(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        message: 'Vendors retrieved successfully',
+        data: vendors,
+      });
+    });
+
+    it('should return 404 when no vendors are found', async () => {
+      const getAllVendorsMock = jest.spyOn(VendorService, 'getAllVendors');
+      getAllVendorsMock.mockResolvedValueOnce([]);
+
+      await vendorController.getAllVendors(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        message: 'No vendors found',
+      });
+    });
+  });
+
+  describe('getVendorById', () => {
+    it('should retrieve a vendor by id successfully', async () => {
+      const vendor: Partial<Vendor> = {
+        store_name: 'Test Store',
+        store_description: 'This is a test store',
+        user_id: 'testuser',
+      };
+
+      const getVendorByIdMock = jest.spyOn(VendorService, 'getVendorById');
+      getVendorByIdMock.mockResolvedValueOnce(vendor as Vendor);
+
+      req.params = { vendor_id: 'testvendor' };
+      await vendorController.getVendorById(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        message: 'Vendor retrieved successfully',
+        data: vendor,
+      });
+    });
+
+    it('should return 400 when vendor_id is not provided', async () => {
+      await vendorController.getVendorById(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        message: 'Vendor ID is required',
+      });
+    });
+
+    it('should return 404 when the vendor is not found', async () => {
+      const getVendorByIdMock = jest.spyOn(VendorService, 'getVendorById');
+      getVendorByIdMock.mockResolvedValueOnce(null as never);
+
+      req.params = { vendor_id: 'testvendor' };
+      await vendorController.getVendorById(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        message: 'Vendor not found',
+      });
+    });
+  });
+
+  describe('updateVendor', () => {
+    it('should update a vendor successfully', async () => {
+      const vendor: Partial<Vendor> = {
+        store_name: 'Test Store',
+        store_description: 'This is a test store',
+        user_id: 'testuser',
+      };
+
+      const updateVendorMock = jest.spyOn(VendorService, 'updateVendor');
+      updateVendorMock.mockResolvedValueOnce(vendor as Vendor);
+
+      req.params = { vendor_id: 'testvendor' };
+      req.body = {
+        store_name: 'Updated Store',
+        store_description: 'This is an updated test store',
+      };
+      await vendorController.updateVendor(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        message: 'Vendor updated successfully',
+        data: vendor,
+      });
+    });
+
+    it('should return 400 when vendor_id is not provided', async () => {
+      await vendorController.updateVendor(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        message: 'Vendor ID is required',
+      });
+    });
+
+    it('should return 404 when the vendor is not found', async () => {
+      const updateVendorMock = jest.spyOn(VendorService, 'updateVendor');
+      updateVendorMock.mockResolvedValueOnce(null as never);
+
+      req.params = { vendor_id: 'testvendor' };
+      await vendorController.updateVendor(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        message: 'Vendor not found',
+      });
+    });
+  });
+
+  describe('deleteVendor', () => {
+    it('should delete a vendor successfully', async () => {
+      const deleteVendorMock = jest.spyOn(VendorService, 'deleteVendor');
+      deleteVendorMock.mockResolvedValueOnce();
+
+      req.params = { vendor_id: 'testvendor' };
+      await vendorController.deleteVendor(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        message: 'Vendor deleted successfully',
+      });
+    });
+
+    it('should return 400 when vendor_id is not provided', async () => {
+      await vendorController.deleteVendor(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        message: 'Vendor ID is required',
+      });
+    });
+
+    it('should return 404 when the vendor is not found', async () => {
+      const deleteVendorMock = jest.spyOn(VendorService, 'deleteVendor');
+      deleteVendorMock.mockRejectedValueOnce(new Error('Vendor not found'));
+
+      req.params = { vendor_id: 'testvendor' };
+      await vendorController.deleteVendor(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        message: 'Vendor not found',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## ℹ️ Description

After getting all in-app notifications, a user should be allowed to mark one of them or all of them as read

Fixes #(issue)

## 🧪 How can this be tested?

This should be testing using the update notifications endpoint on swagger

## 📍 Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature or Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## ✅ Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have created a loom video for the new feature or enhancement
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
